### PR TITLE
docs: add Apache-2.0 license metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "easy-llm-cli",
   "version": "0.1.12",
+  "license": "Apache-2.0",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -7,6 +7,7 @@
     "url": "git+https://github.com/ConardLi/easy-llm-cli.git"
   },
   "type": "module",
+  "license": "Apache-2.0",
   "main": "dist/index.js",
   "bin": {
     "gemini": "dist/index.js"


### PR DESCRIPTION
Adds missing Apache-2.0 license metadata to root package.json and packages/cli/package.json as requested in charles-microbounties#804.